### PR TITLE
add monotonic counter interface for rollback protection

### DIFF
--- a/db.go
+++ b/db.go
@@ -501,8 +501,9 @@ type DB struct {
 	// compaction concurrency
 	openedAt time.Time
 
-	keyManager *edg.KeyManager
-	txLock     sync.Mutex
+	keyManager       *edg.KeyManager
+	txLock           sync.Mutex
+	monotonicCounter uint64
 }
 
 var _ Reader = (*DB)(nil)

--- a/edg.go
+++ b/edg.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package estore
+
+import (
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+var edgMonotonicCounterKey = []byte("!EDGELESS_MONOTONIC_COUNTER")
+
+func (d *DB) edgGetMonotonicCounterFromStore() (uint64, error) {
+	value, closer, err := d.Get(edgMonotonicCounterKey)
+	if errors.Is(err, ErrNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	defer closer.Close()
+	return binary.LittleEndian.Uint64(value), nil
+}
+
+func (d *DB) edgSetMonotonicCounterOnStore(value uint64) error {
+	return d.Set(edgMonotonicCounterKey, binary.LittleEndian.AppendUint64(nil, value), nil)
+}
+
+func (d *DB) edgVerifyFreshness() error {
+	if d.opts.SetMonotonicCounter == nil {
+		return nil
+	}
+
+	// get counter from trusted source
+	sourceCount, err := d.opts.SetMonotonicCounter(0)
+	if err != nil {
+		return errors.Wrap(err, "getting monotonic counter from trusted source")
+	}
+
+	// get counter from store
+	storeCount, err := d.edgGetMonotonicCounterFromStore()
+	if err != nil {
+		return errors.Wrap(err, "getting monotonic counter from store")
+	}
+
+	if storeCount < sourceCount {
+		return errors.Newf("rollback detected: store counter: %v, trusted source counter: %v", storeCount, sourceCount)
+	}
+	if storeCount > sourceCount {
+		d.opts.Logger.Infof("WARNING: open: monotonic counter source lags behind: store counter: %v, source counter: %v", storeCount, sourceCount)
+		// will be synced on next tx commit
+	}
+
+	d.monotonicCounter = storeCount
+	return nil
+}

--- a/internal/metamorphic/crossversion/crossversion_test.go
+++ b/internal/metamorphic/crossversion/crossversion_test.go
@@ -365,7 +365,7 @@ func (f *pebbleVersions) String() string {
 		if i > 0 {
 			fmt.Fprint(&buf, " ")
 		}
-		fmt.Fprintf(&buf, v.SHA)
+		fmt.Fprint(&buf, v.SHA)
 	}
 	return buf.String()
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -2087,7 +2087,7 @@ func BenchmarkIteratorSeqSeekGEWithBounds(b *testing.B) {
 						valid = iter.Next()
 					}
 					if iter.Error() != nil {
-						b.Fatalf(iter.Error().Error())
+						b.Fatal(iter.Error().Error())
 					}
 				}
 				iter.Close()
@@ -2398,17 +2398,17 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 			t.Fatalf("iteration didn't produce identical results")
 		}
 		if hasP1 && !bytes.Equal(iter1.Key(), iter2.Key()) {
-			t.Fatalf(fmt.Sprintf("iteration didn't produce identical point keys: %s, %s", iter1.Key(), iter2.Key()))
+			t.Fatalf("iteration didn't produce identical point keys: %s, %s", iter1.Key(), iter2.Key())
 		}
 		if hasR1 {
 			// Confirm that the range key is the same.
 			b1, e1 := iter1.RangeBounds()
 			b2, e2 := iter2.RangeBounds()
 			if !bytes.Equal(b1, b2) || !bytes.Equal(e1, e2) {
-				t.Fatalf(fmt.Sprintf(
+				t.Fatalf(
 					"iteration didn't produce identical range keys: [%s, %s], [%s, %s]",
 					b1, e1, b2, e2,
-				))
+				)
 			}
 
 		}
@@ -2416,7 +2416,7 @@ func TestRangeKeyMaskingRandomized(t *testing.T) {
 		// Confirm that the returned point key wasn't hidden.
 		for j, pkey := range keys {
 			if bytes.Equal(iter1.Key(), pkey) && pointKeyHidden[j] {
-				t.Fatalf(fmt.Sprintf("hidden point key was exposed %s %d", pkey, keyTimeStamps[j]))
+				t.Fatalf("hidden point key was exposed %s %d", pkey, keyTimeStamps[j])
 			}
 		}
 	}

--- a/open.go
+++ b/open.go
@@ -72,6 +72,18 @@ func TableCacheSize(maxOpenFiles int) int {
 
 // Open opens a DB whose files live in the given directory.
 func Open(dirname string, opts *Options) (db *DB, _ error) {
+	db, err := open(dirname, opts)
+	if err != nil {
+		return db, err
+	}
+	if err := db.edgVerifyFreshness(); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func open(dirname string, opts *Options) (db *DB, _ error) {
 	// Make a copy of the options so that we don't mutate the passed in options.
 	opts = opts.Clone()
 	opts = opts.EnsureDefaults()

--- a/options.go
+++ b/options.go
@@ -470,6 +470,17 @@ type Options struct {
 	// EncryptionKey is the master key for encryption at rest. Must be 16, 24, or 32 bytes.
 	EncryptionKey []byte
 
+	// SetMonotonicCounter is a callback that EStore invokes to provide rollback protection by using a trusted monotonic counter.
+	//
+	// The behavior of the counter must be the following:
+	// If the passed value is greater than the counter's value, it is set as the new value and the old value is returned.
+	// Otherwise, the value is not changed and the current value is returned.
+	//
+	// If you use this feature, you should perform all write operations inside transactions because only these will be protected.
+	//
+	// If not set, rollback protection is disabled.
+	SetMonotonicCounter func(uint64) (uint64, error)
+
 	// Sync sstables periodically in order to smooth out writes to disk. This
 	// option does not provide any persistency guarantee, but is used to avoid
 	// latency spikes if the OS automatically decides to write out a large chunk


### PR DESCRIPTION
Add an option to use a trusted monotonic counter source to protect the store from rollback attacks. See the comment in options.go to understand how this is meant to be used.